### PR TITLE
Adding functionality to accept payments on behalf of sub-merchants

### DIFF
--- a/lib/api/payments.js
+++ b/lib/api/payments.js
@@ -7,7 +7,7 @@ function Payments(beanstream) {
   if (!(this instanceof Payments)) {
     return new Payments();
   }
-  
+
   this._api = new api(beanstream);
 }
 
@@ -16,15 +16,23 @@ Payments.prototype = {
   makePayment: function(paymentRequest) {
     // build url
     var url = this._api._beanstream.getRequestUrl() + "payments";
-    
+
     // post request
     return this._api._POST(url, this._api._beanstream.getConfigField("merchantId"), this._api._beanstream.getConfigField("paymentsApiKey"), paymentRequest);
+  },
+
+  makeSubMerchantPayment: function(subMerchantId, subMerchantPaymentsApiKey, paymentRequest) {
+    // build url
+    var url = this._api._beanstream.getRequestUrl() + "payments";
+
+    // post request
+    return this._api._POST(url, subMerchantId, subMerchantPaymentsApiKey, paymentRequest);
   },
 
   completePayment: function(transId, paymentRequest) {
     // build url
     var url = this._api._beanstream.getRequestUrl() + "payments/${transId}/completions";
-    
+
     var ids = {'transId': transId};
 
     // post request
@@ -34,7 +42,7 @@ Payments.prototype = {
   getPayment: function(transId) {
     // build url
     var url = this._api._beanstream.getRequestUrl() + "payments/${transId}";
-    
+
     var ids = {'transId': transId};
 
     // get request
@@ -44,7 +52,7 @@ Payments.prototype = {
   voidPayment: function(transId, paymentRequest) {
     // build url
     var url = this._api._beanstream.getRequestUrl() + "payments/${transId}/void";
-    
+
     var ids = {'transId': transId};
 
     // get request
@@ -54,7 +62,7 @@ Payments.prototype = {
   returnPayment: function(transId, paymentRequest) {
     // build url
     var url = this._api._beanstream.getRequestUrl() + "payments/${transId}/returns";
-    
+
     var ids = {'transId': transId};
 
     // get request

--- a/test/api/payments.js
+++ b/test/api/payments.js
@@ -37,6 +37,31 @@ describe("api", function() {
           done();
         });
     });
+    it('Should successfully make payment on behalf of a sub-merchant', function(done) {
+      var cardPayment = {
+        order_number: testUtil.getOrderNum("payment"),
+        amount:10.00,
+        payment_method:"card",
+        card:{
+          name:"John Doe",
+          number:"5100000010001004",
+          expiry_month:"02",
+          expiry_year:"19",
+          cvd:"123"
+        }
+      };
+      beanstream.payments.makeSubMerchantPayment('300202846', 'bcB6d13774E9419787967bcAc9Fb84E0', cardPayment)
+        .then(function(response){
+          expect(response).to.have.property('approved', '1');
+          expect(response).to.have.property('type', 'P');
+          done();
+        })
+        .catch(function(error){
+          console.log(error);
+          expect(error.message).to.be.null;
+          done();
+        });
+    });
     it('Should get a declined payment', function(done) {
       var cardPayment = {
         order_number: testUtil.getOrderNum("payment"),
@@ -52,7 +77,8 @@ describe("api", function() {
       };
       beanstream.payments.makePayment(cardPayment)
         .then(function(response){
-          expect(false).to.be.true; // should not get here
+          assert.fail(0, 1, 'Meaningful Error about why this code should not be reached.');
+          // expect(false).to.be.true; // should not get here
           done();
         })
         .catch(function(error){
@@ -65,7 +91,7 @@ describe("api", function() {
           );
           done();
         });
-      
+
     });
     it('Should successfully get a past payment', function(done) {
 
@@ -130,7 +156,7 @@ describe("api", function() {
         .then(function(transaction) {
           expect(transaction).to.have.property('id', transactionId);
           expect(transaction).to.have.property('amount', 10);
-          expect(transaction.card).to.deep.equal({ 
+          expect(transaction.card).to.deep.equal({
             name: 'John Doe',
             expiry_month: '02',
             expiry_year: '19',
@@ -215,7 +241,7 @@ describe("api", function() {
           done();
         });
     });
-    
+
     it('Should successfully void a payment', function(done) {
       var cardPayment = {
         order_number: testUtil.getOrderNum("payment"),
@@ -303,7 +329,7 @@ describe("api", function() {
       testUtil.tokenizeCard(card)
         .then(function(tokenResp) {
           expect(tokenResp).to.have.property('token');
-          
+
           var tokenPayment = {
             order_number: testUtil.getOrderNum("token"),
             amount:12.00,
@@ -340,7 +366,7 @@ describe("api", function() {
       testUtil.tokenizeCard(card)
         .then(function(tokenResp) {
           expect(tokenResp).to.have.property('token');
-          
+
           var tokenPayment = {
             order_number: testUtil.getOrderNum("token"),
             amount:12.00,
@@ -375,7 +401,7 @@ describe("api", function() {
           expiry_year:"19",
           cvd:"123"
         };
-      
+
       testUtil.tokenizeCard(card)
         .then(function(response){
           expect(response).to.have.property('token');


### PR DESCRIPTION
supply sub-merchant ID, sub-merchant pay api key, and then regular payment.

just a convenience method, so I won't have to call the api manually when I want to switch between accepting for sub-merchants and accepting for my merchant. 